### PR TITLE
Make it work when the main job is qsubbed on the cluster

### DIFF
--- a/distribute.m
+++ b/distribute.m
@@ -269,7 +269,11 @@ function varargout = distribute_server_batch(opt, func, args, flags, access, N)
 
     % Filenames
     % ---------
-    uid      = char(java.util.UUID.randomUUID()); % General UID
+    if exist('java.util.UUID', 'class')
+        uid      = char(java.util.UUID.randomUUID()); % General UID
+    else
+        uid = datestr(now, 'yyyymmddTHHMMSS');
+    end
     mainname = ['main_' uid];
     fnames   = ['fnames_' uid '.mat'];     % job nb <-> data filename
     matin    = cell(1,N);                  % input data filenames
@@ -285,7 +289,11 @@ function varargout = distribute_server_batch(opt, func, args, flags, access, N)
     % Write data
     % ----------
     for n=1:N
-        uid1 = char(java.util.UUID.randomUUID());
+        if exist('java.util.UUID', 'class')
+            uid1 = char(java.util.UUID.randomUUID());
+        else
+            uid1 = num2str(n);
+        end
         matin{n}   = ['in_' uid '_' uid1 '.mat'];
         matout{n}  = ['out_' uid '_' uid1 '.mat'];
         
@@ -325,7 +333,10 @@ function varargout = distribute_server_batch(opt, func, args, flags, access, N)
         '\n'                        ...
         'matlab_cmd="'];
     if ~isempty(opt.matlab.priv.add)
-        batch_script = [batch_script 'addpath(genpath(' opt.matlab.priv.add '));'];
+        batch_script = [batch_script 'addpath(' opt.matlab.priv.add ');'];
+    end
+    if ~isempty(opt.matlab.priv.addsub)
+        batch_script = [batch_script 'addpath(' opt.matlab.priv.addsub ');'];
     end
     batch_script = [batch_script ...
             'load(fullfile(''' opt.server.folder ''',''' fnames '''),''matin'',''matout'');' ...
@@ -349,7 +360,7 @@ function varargout = distribute_server_batch(opt, func, args, flags, access, N)
     for i=1:numel(opt.client.source)
         cmd = [cmd 'source ' opt.client.source{i} ' >/dev/null 2>&1 ; '];
     end
-    cmd = [cmd opt.ssh.bin ' ' opt.server.login '@' opt.server.ip ' "'];
+    cmd = [cmd opt.ssh.bin ' ' opt.ssh.opt ' ' opt.server.login '@' opt.server.ip ' "'];
     for i=1:numel(opt.server.source)
         cmd = [cmd 'source ' opt.server.source{i} ' >/dev/null 2>&1 ; '];
     end
@@ -404,7 +415,7 @@ function varargout = distribute_server_batch(opt, func, args, flags, access, N)
     for i=1:numel(opt.client.source)
         cmd = [cmd 'source ' opt.client.source{i} ' >/dev/null 2>&1 ; '];
     end
-    cmd = [cmd opt.ssh.bin ' ' opt.server.login '@' opt.server.ip ' "'];
+    cmd = [cmd opt.ssh.bin ' ' opt.ssh.opt ' ' opt.server.login '@' opt.server.ip ' "'];
     for i=1:numel(opt.server.source)
         cmd = [cmd 'source ' opt.server.source{i} ' >/dev/null 2>&1 ; '];
     end
@@ -526,11 +537,20 @@ function varargout = distribute_server_ind(opt, func, args, flags, access, N)
     mainerr  = cell(1,N);
     matin    = cell(1,N);
     matout   = cell(1,N);
+    if exist('java.util.UUID', 'class')
+        uid1 = ''; % General UID
+    else
+        uid1 = datestr(now, 'yyyymmddTHHMMSS');
+    end
     for n=1:N
 
         % Filenames
         % ---------
-        uid         = char(java.util.UUID.randomUUID()); % General UID
+        if exist('java.util.UUID', 'class')
+            uid = char(java.util.UUID.randomUUID());
+        else
+            uid = [uid1 '_' num2str(n)];
+        end
         mainname{n} = ['main_' uid];
         mainsh{n}   = ['main_' uid '.sh'];        % main bash script
         mainout{n}  = ['main_cout_' uid '.log'];  % main output file
@@ -572,7 +592,10 @@ function varargout = distribute_server_ind(opt, func, args, flags, access, N)
             '\n'                        ...
             'matlab_cmd="'];
         if ~isempty(opt.matlab.priv.add)
-            batch_script = [batch_script 'addpath(genpath(' opt.matlab.priv.add '));'];
+            batch_script = [batch_script 'addpath(' opt.matlab.priv.add ');'];
+        end
+        if ~isempty(opt.matlab.priv.addsub)
+            batch_script = [batch_script 'addpath(' opt.matlab.priv.addsub ');'];
         end
         batch_script = [batch_script ...
                 'load(fullfile(''' opt.server.folder ''',''' matin{n} '''),''argin'');' ...
@@ -595,7 +618,7 @@ function varargout = distribute_server_ind(opt, func, args, flags, access, N)
         for i=1:numel(opt.client.source)
             cmd = [cmd 'source ' opt.client.source{i} ' >/dev/null 2>&1 ; '];
         end
-        cmd = [cmd opt.ssh.bin ' ' opt.server.login '@' opt.server.ip ' "'];
+        cmd = [cmd opt.ssh.bin ' ' opt.ssh.opt ' ' opt.server.login '@' opt.server.ip ' "'];
         for i=1:numel(opt.server.source)
             cmd = [cmd 'source ' opt.server.source{i} ' >/dev/null 2>&1 ; '];
         end
@@ -657,7 +680,7 @@ function varargout = distribute_server_ind(opt, func, args, flags, access, N)
     for i=1:numel(opt.client.source)
         cmd = [cmd 'source ' opt.client.source{i} ' >/dev/null 2>&1 ; '];
     end
-    cmd = [cmd opt.ssh.bin ' ' opt.server.login '@' opt.server.ip ' "'];
+    cmd = [cmd opt.ssh.bin ' ' opt.ssh.opt ' ' opt.server.login '@' opt.server.ip ' "'];
     for i=1:numel(opt.server.source)
         cmd = [cmd 'source ' opt.server.source{i} ' >/dev/null 2>&1 ; '];
     end
@@ -777,7 +800,7 @@ function opt = estimate_mem(opt,N)
         for i=1:numel(opt.client.source)
             cmd = [cmd 'source ' opt.client.source{i} ' >/dev/null 2>&1 ; '];
         end
-        cmd = [cmd opt.ssh.bin ' ' opt.server.login '@' opt.server.ip ' "'];
+        cmd = [cmd opt.ssh.bin ' ' opt.ssh.opt ' ' opt.server.login '@' opt.server.ip ' "'];
         for i=1:numel(opt.server.source)
             cmd = [cmd 'source ' opt.server.source{i} ' >/dev/null 2>&1 ; '];
         end
@@ -818,7 +841,7 @@ function opt = estimate_mem(opt,N)
             for i=1:numel(opt.client.source)
                 cmd = [cmd 'source ' opt.client.source{i} ' >/dev/null 2>&1 ; '];
             end
-            cmd = [cmd opt.ssh.bin ' ' opt.server.login '@' opt.server.ip ' "'];
+            cmd = [cmd opt.ssh.bin ' ' opt.ssh.opt ' ' opt.server.login '@' opt.server.ip ' "'];
             for i=1:numel(opt.server.source)
                 cmd = [cmd 'source ' opt.server.source{i} ' >/dev/null 2>&1 ; '];
             end

--- a/distribute.m
+++ b/distribute.m
@@ -907,7 +907,7 @@ end
 function fprintf_job(opt,N,t)            
     date = datestr(now,'mmmm dd, yyyy HH:MM:SS');
     if nargin<3        
-        fprintf('----------------------------------------------\n')
+        fprintf('\n----------------------------------------------\n')
         if opt.job.batch
             fprintf('%s | Batch job submitted to cluster (N = %i)\n',date,N)
         else

--- a/distribute_default.m
+++ b/distribute_default.m
@@ -27,6 +27,7 @@ function opt = distribute_default(opt)
 % -----------
 % ssh.type      - SSH software to use 'ssh'/'putty'/[try to detect]
 % ssh.bin       - Path to the ssh binary [try to detect]
+% ssh.opt       - SSH options ['-x']
 % sched.sub     - Path to the submit binary [try to detect]
 % sched.stat    - Path to the stat binary [try to detect]
 % sched.acct    - Path to the acct binary [try to detect]
@@ -44,6 +45,7 @@ function opt = distribute_default(opt)
 % ------
 % matlab.bin    - Path to matlab binary [try to detect]
 % matlab.add    - Paths to add to Matlab path [{}]
+% matlab.addsub - Paths to add to Matlab path, with subdorectories [{}]
 % matlab.opt    - Commandline options to pass to matlab
 %                 [{'-nojvm' '-nodesktop' '-nosplash' '-singleCompThread'}]
 % spm.path      - Path to SPM [try to detect]

--- a/distribute_default.m
+++ b/distribute_default.m
@@ -170,6 +170,12 @@ function opt = distribute_default(opt)
     if ~isfield(opt.job, 'est_mem')
         opt.job.est_mem = true;
     end
+    if ~isfield(opt.job, 'sd')
+        opt.job.sd = 0.1;
+    end
+    if ~isfield(opt.job, 'use_dummy')
+        opt.job.use_dummy = false;
+    end
     if ~isfield(opt, 'optim')
         opt.optim = struct;
     end


### PR DESCRIPTION
- Workarounds when java is not available
- Add option to disable X11 forwarding in ssh
- Two different matlab path options depending if we want all subfolders added or not (+ a fix)